### PR TITLE
fix release by adding required info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           pnpm run test
       - name: Create Release
         env:
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3--canary.4.3ea4e68.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ndelangen/fs-extra-unified@1.0.3--canary.4.3ea4e68.0
  # or 
  yarn add @ndelangen/fs-extra-unified@1.0.3--canary.4.3ea4e68.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
